### PR TITLE
Undo double-negative on input

### DIFF
--- a/lib/GPIOAccessory.js
+++ b/lib/GPIOAccessory.js
@@ -85,7 +85,7 @@ GPIOAccessory.prototype.interruptPoll = function(callback) {
 
     //Set hardware interrupt on both edges
     sysfs.edge = 'both';
-    sysfs.activeLow = (!self.inverted * 1);
+    //sysfs.activeLow = (!self.inverted * 1);
 
     var valuefd = FS.openSync(sysfs.valuePath, 'r');
         


### PR DESCRIPTION
Thanks for this great tool.  The new interrupt code for reading input was applying the `inverted` config property _twice_—once via sysFS as `active_low`, and once again in `getOn`.  Since `activeLow` was being set on if _not_ inverted, this meant the input would only behave like an inverted contact (inverted off: do set active_low, don't alter the `wpi.digitalRead` value; inverted on: don't set active_low, do alter the `wpi.digitalRead` value).  So far just leaving `active_low` as is (0) works for either `inverted` state.   

I left it there, but `gpiopin.active_low = ((gpiopins[i].pull === "down") * 1);` doesn't seem to do anything either.  Also, mixing pull-down state and inverting logic is confusing.  I think of pull-up/down as "what to do if the wire gets cut".  I.e. no information, but we want to tie it to a definite state.  