### PR TITLE
Update to Set Motion Sensor Accessory Type

### DIFF
--- a/config-platform-sample.json
+++ b/config-platform-sample.json
@@ -3,65 +3,26 @@
 	    "name": "Homebridge",
 	    "username": "CC:22:3D:E3:CE:30",
 	    "port": 51826,
-	    "pin": "031-45-155"
+	    "pin": "123-45-678"
     },
-    "description": "This is an example configuration file with one fake accessory and one fake platform.",
+    "description": "This is an example configuration file with ContactSensor, MotionSensor, and Switch types.",
 
     "platforms": [
         {
             "platform" : "WiringPiPlatform",
             "name" : "Pi GPIO (WiringPi)",
-            "overrideCache" : "false",
+            "overrideCache" : "true",
             "autoExport" : "true",
-	        "gpiopins" : [{
-		        "name" : "GPIO2",
-		        "pin"  : 27,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-	        },{
-		        "name" : "GPIO3",
-		        "pin"  : 22,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-            },{
-		        "name" : "GPIO4",
-		        "pin"  : 23,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-            },{
-		        "name" : "GPIO5",
-		        "pin"  : 24,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-            },{
-		        "name" : "GPIO6",
-		        "pin"  : 25,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-            },{
-		        "name" : "GPIO7",
-		        "pin"  : 4,
-                "enabled" : "true",
-		        "mode" : "out",
-                "pull" : "down",
-		        "inverted" : "false",
-                "duration" : 0
-	        }]
+	        "gpiopins" : 	
+		[
+			{	"type" : "ContactSensor",	"name" : "PHYSICAL_PIN_21", 	"pin": 9, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "ContactSensor",	"name" : "PHYSICAL_PIN_19", 	"pin": 10, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_23", 	"pin": 11, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_32", 	"pin": 12, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_33", 	"pin": 13, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{ 	"type" : "Switch",		"name" : "PHYSICAL_PIN_13",     "pin": 27,	"enabled" : "true", 	"mode" : "out",	"pull" : "down", "inverted" : "false", "duration" : 0   }
+
+		]
         }
     ]
 }

--- a/config-platform-sample.json
+++ b/config-platform-sample.json
@@ -16,9 +16,9 @@
 	        "gpiopins" : 	
 		[
 			{	"type" : "ContactSensor",	"name" : "PHYSICAL_PIN_21", 	"pin": 9, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
-			{	"type" : "ContactSensor",	"name" : "PHYSICAL_PIN_19", 	"pin": 10, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
-			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_23", 	"pin": 11, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
-			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_32", 	"pin": 12, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "LeakSensor",		"name" : "PHYSICAL_PIN_19", 	"pin": 10, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "OccupancySensor",	"name" : "PHYSICAL_PIN_23", 	"pin": 11, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
+			{	"type" : "SmokeSensor",		"name" : "PHYSICAL_PIN_32", 	"pin": 12, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
 			{	"type" : "MotionSensor",	"name" : "PHYSICAL_PIN_33", 	"pin": 13, 	"enabled": "true",	"mode": "in",	"pull": "down"	},
 			{ 	"type" : "Switch",		"name" : "PHYSICAL_PIN_13",     "pin": 27,	"enabled" : "true", 	"mode" : "out",	"pull" : "down", "inverted" : "false", "duration" : 0   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 const wpi = require('node-wiring-pi');
 const chalk = require('chalk');
+const red = chalk.red.bold;
+const magenta = chalk.magenta.bold;
+const cyan = chalk.cyan.bold;
+const yellow = chalk.yellow.bold;
+const green = chalk.green.bold;
+
 
 
 const sysfs = require('./lib/readExports.js');
@@ -98,7 +104,11 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
   if (accessory.getService(Service.ContactSensor) && accessory.context.mode === "in") {
     accessory.getService(Service.ContactSensor)
       .getCharacteristic(Characteristic.ContactSensorState)
-      .on('get', gpioAccessory.getOn.bind(gpioAccessory));
+      .on('get', gpioAccessory.getOn.bind(gpioAccessory))
+      .on('change', (data) => 
+          {
+            console.log(magenta("*Debug* CHANGE event for Contact Sensor, new value is: " + data.newValue));
+        });
 
       platform.log("Setting up interrupt callback");
       gpioAccessory.interruptPoll(function() {

--- a/index.js
+++ b/index.js
@@ -116,6 +116,41 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
       });
   }
 
+
+if (accessory.getService(Service.LeakSensor) && accessory.context.mode === "in") {
+      accessory.getService(Service.LeakSensor)
+          .getCharacteristic(Characteristic.LeakDetected)
+          .on('get', gpioAccessory.getOn.bind(gpioAccessory));
+
+      platform.log("Setting up interrupt callback");
+      gpioAccessory.interruptPoll(function () {
+          accessory.getService(Service.LeakSensor).getCharacteristic(Characteristic.LeakDetected).getValue();
+      });
+  }
+
+if (accessory.getService(Service.SmokeSensor) && accessory.context.mode === "in") {
+      accessory.getService(Service.SmokeSensor)
+          .getCharacteristic(Characteristic.SmokeDetected)
+          .on('get', gpioAccessory.getOn.bind(gpioAccessory));
+
+      platform.log("Setting up interrupt callback");
+      gpioAccessory.interruptPoll(function () {
+          accessory.getService(Service.SmokeSensor).getCharacteristic(Characteristic.SmokeDetected).getValue();
+      });
+  }
+
+if (accessory.getService(Service.OccupancySensor) && accessory.context.mode === "in") {
+      accessory.getService(Service.OccupancySensor)
+          .getCharacteristic(Characteristic.OccupancyDetected)
+          .on('get', gpioAccessory.getOn.bind(gpioAccessory));
+
+      platform.log("Setting up interrupt callback");
+      gpioAccessory.interruptPoll(function () {
+          accessory.getService(Service.OccupancySensor).getCharacteristic(Characteristic.OccupancyDetected).getValue();
+      });
+  }
+
+
   // Handle the 'identify' event
   accessory.on('identify', function(paired, callback) {
     platform.log(accessory.displayName, "Identify!!!");
@@ -160,6 +195,15 @@ WPiPlatform.prototype.addGPIOPin = function(gpiopin) {
         break;
       case (gpiopin.mode === "in") && (gpiopin.type === "MotionSensor"):
           newAccessory.addService(Service.MotionSensor, gpiopin.name);
+          break;
+      case (gpiopin.mode === "in") && (gpiopin.type === "LeakSensor"):
+          newAccessory.addService(Service.LeakSensor, gpiopin.name);
+          break;
+      case (gpiopin.mode === "in") && (gpiopin.type === "OccupancySensor"):
+          newAccessory.addService(Service.OccupancySensor, gpiopin.name);
+          break;
+      case (gpiopin.mode === "in") && (gpiopin.type === "SmokeSensor"):
+          newAccessory.addService(Service.SmokeSensor, gpiopin.name);
           break;
       case (gpiopin.mode === "in"): //default to ContactSensor if type is not specified
         newAccessory.addService(Service.ContactSensor, gpiopin.name);

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
       .on('get', gpioAccessory.getOn.bind(gpioAccessory))
       .on('change', (data) => 
           {
-            console.log(magenta("*Debug* CHANGE event for Contact Sensor, new value is: " + data.newValue));
+            console.log("Contact Sensor " + cyan(accessory.context.name) +" Changed to new value of: " + cyan(data.newValue));
         });
 
       platform.log("Setting up interrupt callback");
@@ -119,7 +119,11 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
   if (accessory.getService(Service.MotionSensor) && accessory.context.mode === "in") {
       accessory.getService(Service.MotionSensor)
           .getCharacteristic(Characteristic.MotionDetected)
-          .on('get', gpioAccessory.getOn.bind(gpioAccessory));
+          .on('get', gpioAccessory.getOn.bind(gpioAccessory))
+      .on('change', (data) => 
+          {
+            console.log("Motion Sensor " + cyan(accessory.context.name) +" Changed to new value of: " + cyan(data.newValue));
+        });
 
       platform.log("Setting up interrupt callback");
       gpioAccessory.interruptPoll(function () {

--- a/index.js
+++ b/index.js
@@ -1,39 +1,4 @@
-const wpi = require('node-wiring-pi');
-
-
-const sysfs = require('./lib/readExports.js');
-const GPIOAccessory = require('./lib/GPIOAccessory.js');
-const AutoExport = require('./lib/autoExport.js');
-
-var Accessory, Service, Characteristic, UUIDGen;
-
-
-module.exports = function(homebridge) {
-  
-  // Accessory must be created from PlatformAccessory Constructor
-  Accessory = homebridge.platformAccessory;
-
-  // Service and Characteristic are from hap-nodejs
-  Service = homebridge.hap.Service;
-  Characteristic = homebridge.hap.Characteristic;
-  UUIDGen = homebridge.hap.uuid;
-
-  homebridge.registerPlatform("homebridge-gpio-wpi2", "WiringPiPlatform", WPiPlatform, false);
-}
-
-// Platform constructor
-function WPiPlatform(log, config, api) {
-  log("WORK IN PROGRESS... Report issues on https://github.com/rsg98/homebridge-gpio-wpi2");
-  var platform = this;
-  this.log = log;
-  this.config = config;
-  this.gpiopins = this.config.gpiopins || [];
-  this.accessories = [];
-
-  //Export pins via sysfs if enabled with autoExport
-  if((typeof this.config.autoExport !== undefined) && (this.config.autoExport === "true"))
-  {
-      AutoExport(this.log, this.gpiopins);
+const wpi =log, this.gpiopins);
   }
 
   //Configure wiring pi using 'sys' mode - requires pins to

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ WPiPlatform.prototype.addGPIOPin = function(gpiopin) {
       .setCharacteristic(Characteristic.SerialNumber, platform.config.serial ? platform.config.serial : "Default-SerialNumber");
 
     switch(true) {
-      case (gpiopin.mode === "out") && (gpiopin.type !== "MotionSensor"):
+      case (gpiopin.mode === "out") && (gpiopin.type === "Switch"):
         newAccessory.addService(Service.Switch, gpiopin.name);
         break;
       case (gpiopin.mode === "in") && (gpiopin.type === "MotionSensor"):

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const wpi = require('node-wiring-pi');
+const chalk = require('chalk');
 
 
 const sysfs = require('./lib/readExports.js');

--- a/index.js
+++ b/index.js
@@ -1,11 +1,4 @@
 const wpi = require('node-wiring-pi');
-const chalk = require('chalk');
-const red = chalk.red.bold;
-const magenta = chalk.magenta.bold;
-const cyan = chalk.cyan.bold;
-const yellow = chalk.yellow.bold;
-const green = chalk.green.bold;
-
 
 
 const sysfs = require('./lib/readExports.js');
@@ -104,11 +97,7 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
   if (accessory.getService(Service.ContactSensor) && accessory.context.mode === "in") {
     accessory.getService(Service.ContactSensor)
       .getCharacteristic(Characteristic.ContactSensorState)
-      .on('get', gpioAccessory.getOn.bind(gpioAccessory))
-      .on('change', (data) => 
-          {
-            console.log("Contact Sensor " + cyan(accessory.context.name) +" Changed to new value of: " + cyan(data.newValue));
-        });
+      .on('get', gpioAccessory.getOn.bind(gpioAccessory));
 
       platform.log("Setting up interrupt callback");
       gpioAccessory.interruptPoll(function() {
@@ -119,11 +108,7 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
   if (accessory.getService(Service.MotionSensor) && accessory.context.mode === "in") {
       accessory.getService(Service.MotionSensor)
           .getCharacteristic(Characteristic.MotionDetected)
-          .on('get', gpioAccessory.getOn.bind(gpioAccessory))
-      .on('change', (data) => 
-          {
-            console.log("Motion Sensor " + cyan(accessory.context.name) +" Changed to new value of: " + cyan(data.newValue));
-        });
+          .on('get', gpioAccessory.getOn.bind(gpioAccessory));
 
       platform.log("Setting up interrupt callback");
       gpioAccessory.interruptPoll(function () {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,39 @@
-const wpi =log, this.gpiopins);
+const wpi = require('node-wiring-pi');
+
+
+const sysfs = require('./lib/readExports.js');
+const GPIOAccessory = require('./lib/GPIOAccessory.js');
+const AutoExport = require('./lib/autoExport.js');
+
+var Accessory, Service, Characteristic, UUIDGen;
+
+
+module.exports = function(homebridge) {
+  
+  // Accessory must be created from PlatformAccessory Constructor
+  Accessory = homebridge.platformAccessory;
+
+  // Service and Characteristic are from hap-nodejs
+  Service = homebridge.hap.Service;
+  Characteristic = homebridge.hap.Characteristic;
+  UUIDGen = homebridge.hap.uuid;
+
+  homebridge.registerPlatform("homebridge-gpio-wpi2", "WiringPiPlatform", WPiPlatform, false);
+}
+
+// Platform constructor
+function WPiPlatform(log, config, api) {
+  log("WORK IN PROGRESS... Report issues on https://github.com/rsg98/homebridge-gpio-wpi2");
+  var platform = this;
+  this.log = log;
+  this.config = config;
+  this.gpiopins = this.config.gpiopins || [];
+  this.accessories = [];
+
+  //Export pins via sysfs if enabled with autoExport
+  if((typeof this.config.autoExport !== undefined) && (this.config.autoExport === "true"))
+  {
+      AutoExport(this.log, this.gpiopins);
   }
 
   //Configure wiring pi using 'sys' mode - requires pins to
@@ -77,7 +112,7 @@ WPiPlatform.prototype.configureAccessory = function(accessory) {
 
       platform.log("Setting up interrupt callback");
       gpioAccessory.interruptPoll(function () {
-          accessory.getService(Service.MotionSensor).getCharacteristic(Characteristic.MotionSensorState).getValue();
+          accessory.getService(Service.MotionSensor).getCharacteristic(Characteristic.MotionDetected).getValue();
       });
   }
 
@@ -184,3 +219,5 @@ WPiPlatform.prototype.statePolling = function () {
   
   }, 2000);
 }
+
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 	"dependencies": {
 		"node-wiring-pi": "^0.0.3",
 		"sleep": "^5.1.0",
-		"epoll" : "^0.1.21",
-		"chalk": ">=2.3.0"
+		"epoll" : "^0.1.21"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"dependencies": {
 		"node-wiring-pi": "^0.0.3",
 		"sleep": "^5.1.0",
-		"epoll" : "^0.1.21"
+		"epoll" : "^0.1.21",
+		"chalk": ">=2.3.0"
 	}
 }


### PR DESCRIPTION
For consideration ...
I've modified the index.js to now allow for an explicit "MotionSensor" input accessory in addition to the "ContactSensor" accessory. 

The accessory type is selected by specifying "type":"ContactSensor" or "type":"MotionSensor" in the config.json file.  Additionally, for output accessories, the user can designate "type":"Switch".

This can probably be modified a bit more as you no longer really need the "mode" setting in index.js since the accessory type will now implicitly determine this.

