### PR TITLE
Fix Inverted, Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ You can run `gpio readall` to generate a table showing how the BCM pin numbers m
           "overrideCache" : "true",
           "autoExport" : "true",
           "gpiopins" : [{
-                "name" : "GPIO2",
+	  	"type":"Switch",
+		"name" : "GPIO2",
                 "pin"  : 27,
                 "enabled" : "true",
                 "mode" : "out",
@@ -63,10 +64,11 @@ You can run `gpio readall` to generate a table showing how the BCM pin numbers m
                 "duration" : 0,
                 "polling" : "true"
 	        },{
+		"type":"MotionSensor",
                 "name" : "GPIO3",
                 "pin"  : 22,
                 "enabled" : "true",
-                "mode" : "out",
+                "mode" : "in",
                 "pull" : "down",
                 "inverted" : "false",
                 "duration" : 0
@@ -89,6 +91,7 @@ You can run `gpio readall` to generate a table showing how the BCM pin numbers m
 
 | Config Item | Valid Values | Description |
 | --- | --- | --- |
+| "type" | "string" | Type of device connected to GPIO. Set to "Switch" for "out" pin mode, or one of "ContactSensor", "LeakSensor", "MotionSensor", "OccupancySensor", or "SmokeSensor" for "in" pin mode | 
 | `name` | `string` | Initial display name for the PIN accessory - can be renamed in HomeKit app (e.g. Home) |
 | `pin` | `number` | The BCM pin number - see Pin Configuration below |
 | `enabled` | `true / false` | Whether you want the module to publish this pin as an accessory |

--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ WPiPlatform.prototype.addGPIOPin = function(gpiopin) {
       .setCharacteristic(Characteristic.SerialNumber, platform.config.serial ? platform.config.serial : "Default-SerialNumber");
 
     switch(true) {
-      case (gpiopin.mode === "out") && (gpiopin.type === "Switch"):
+      case (gpiopin.mode === "out") :
         newAccessory.addService(Service.Switch, gpiopin.name);
         break;
       case (gpiopin.mode === "in") && (gpiopin.type === "MotionSensor"):

--- a/lib/GPIOAccessory.js
+++ b/lib/GPIOAccessory.js
@@ -19,7 +19,7 @@ constructor(log, accessory, wpi, onChar)
     this.context = accessory.context;
     this.wpi = wpi;
     this.onChar = onChar;
-    this.inverted = (this.context.inverted === "true");
+    this.inverted = ((this.context.inverted == "true") || (this.context.inverted == true));
     
     switch(this.context.mode) {
         case "out":

--- a/lib/GPIOAccessory.js
+++ b/lib/GPIOAccessory.js
@@ -19,7 +19,7 @@ constructor(log, accessory, wpi, onChar)
     this.context = accessory.context;
     this.wpi = wpi;
     this.onChar = onChar;
-    this.inverted = ((this.context.inverted == "true") || (this.context.inverted == true));
+    this.inverted = ((this.context.inverted === "true") || (this.context.inverted == true));
     
     switch(this.context.mode) {
         case "out":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "homebridge-gpio-wpi2",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Raspberry Pi GPIO plugin for Homebridge (Wiring-pi backend): https://github.com/nfarina/homebridge",
 	"license": "MIT",
 	"keywords": [


### PR DESCRIPTION
Fixed processing of "inverted" configuration in config.json. Previously code only accepted the string "true" as a true value; updated to also accept Boolean true.

Also updated Readme file to explain use of "type" field and updated package.json number for npm publishing purposes